### PR TITLE
Fix parsing of time for absolute timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.settings/
+.project
+.idea/

--- a/api/Xpunge/implementation.js
+++ b/api/Xpunge/implementation.js
@@ -163,11 +163,19 @@ var Xpunge = class extends ExtensionCommon.ExtensionAPI {
             // Compact the specified folder
             // Can't compact folders that have just been compacted.
             if (nativeFolder.server.type != "imap" && !nativeFolder.expungedBytes) {
+              console.info("XPUNGE: Nothing to do, skipping compacting of folder (", nativeFolder.prettyName, ") on account:", nativeFolder.server.prettyName);
               return;
             }
-            let urlListener = new UrlListener();
-            nativeFolder.compact(urlListener, null);
-            await urlListener.isDone();
+            
+            try {
+              console.info("XPUNGE: Compacting folder (", nativeFolder.prettyName, ") on account:", nativeFolder.server.prettyName);
+              let urlListener = new UrlListener();
+              nativeFolder.compact(urlListener, null);
+              await urlListener.isDone();
+              console.info("XPUNGE: Done");
+            } catch (ex) {
+              console.info("XPUNGE: Failed compacting folder (", nativeFolder.prettyName, ") on account:", nativeFolder.server.prettyName, ex);
+            }
           }
         },
       },

--- a/api/Xpunge/implementation.js
+++ b/api/Xpunge/implementation.js
@@ -87,7 +87,7 @@ var Xpunge = class extends ExtensionCommon.ExtensionAPI {
           const junkFolders = rootFolder.getFoldersWithFlags(Ci.nsMsgFolderFlags.Junk);
           for (let junkFolder of junkFolders) {
             try {
-              console.info("XPUNGE: Emptying junk folder:", junkFolder.prettyName);
+              console.info("XPUNGE: Emptying junk folder (", junkFolder.prettyName, ") for account:", rootFolder.server.prettyName);
               await _emptyJunk(junkFolder);
               console.info("XPUNGE: Done");
 

--- a/license.txt
+++ b/license.txt
@@ -20,10 +20,11 @@ The Original Code is Xpunge.
 
 The Initial Developer of the Original Code is
 Theodore Tegos <xpungetb@gmail.com>.
-Portions created by the Initial Developer are Copyright (C) 2005-2018
+Portions created by the Initial Developer are Copyright (C) 2005
 the Initial Developer. All Rights Reserved.
 
 Contributor(s):
+  John Bieling (Rewrite for Thunderbird 128)
   Dagobert_78 (French Translation)
   Joergen (Danish Translation)
   kiki (Japanese Translation)

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "{786abda0-fd14-d247-bf69-38b2fc18491b}",
-      "strict_min_version": "115.0",
+      "strict_min_version": "128.0",
       "strict_max_version": "130.*"
     }
   },
@@ -14,9 +14,9 @@
 
   "description": "Empties the Trash and Junk folders, and compacts folders in multiple Thunderbird accounts.",
 
-  "version": "4.1.1",
+  "version": "5.0.0",
 
-  "author": "Theodore Tegos",
+  "author": "Theodore Tegos, John Bieling",
 
   "homepage_url": "http://www.theodoretegos.net/mozilla/tb/index.html",
 

--- a/modules/xpunge.mjs
+++ b/modules/xpunge.mjs
@@ -39,15 +39,19 @@ export async function handleXpungeTimer() {
             return;
         }
     }
+
     if (preferences.timer_interval_enabled) {
         await handleIntervalTimer(preferences);
-    };
+    }
 }
 
 async function handleAbsoluteTimer(preferences) {
     const stamp = new Date();
-    const [timer_absolute_hours,timer_absolute_minutes] = preferences.timer_absolute;
-    
+
+    const timeComponents = preferences.timer_absolute.split(":");
+    const timer_absolute_hours = timeComponents[0];
+    const timer_absolute_minutes = timeComponents[1];
+
     let hours = 0;
     if (timer_absolute_hours.indexOf("0") === 0) {
         let stripped_hours_pref_value = timer_absolute_hours.substring(1);
@@ -69,6 +73,7 @@ async function handleAbsoluteTimer(preferences) {
         doTimer();
         return true;
     }
+
     return false;
 }
 

--- a/modules/xpunge.mjs
+++ b/modules/xpunge.mjs
@@ -147,7 +147,7 @@ export async function xpungeMultiple() {
             [
                 await prettyPrintFolderList(trash_folders),
                 await prettyPrintFolderList(junk_folders),
-                await prettyPrintFolderList(compact_folders),
+                await prettyPrintFolderList(compact_folders, true),
             ]
         );
         if (!await browser.Xpunge.confirm(dialogTitle, dialogMsg)) {
@@ -199,7 +199,7 @@ function getYesOrNo(value) {
     return browser.i18n.getMessage(value ? "xpunge_str_yes" : "xpunge_str_no");
 }
 
-async function prettyPrintFolderList(folders) {
+async function prettyPrintFolderList(folders, isForCompacting = false) {
     if (folders.length == 0) {
         return ""
     }
@@ -207,7 +207,11 @@ async function prettyPrintFolderList(folders) {
     for (let folder of folders) {
         let account = await browser.accounts.get(folder.accountId);
         if (folder.isRoot) {
-            list.push(` - ${account.name} ${browser.i18n.getMessage("xpunge_multi_str_compact_whole")}`)
+            if (isForCompacting) {
+                list.push(` - ${account.name} ${browser.i18n.getMessage("xpunge_multi_str_compact_whole")}`)
+            } else {
+                list.push(` - ${account.name}`)
+            }
         } else {
             list.push(` - ${folder.name} @ ${account.name}`)
         }


### PR DESCRIPTION
This PR implements various small changes:

- Adds John Bieling in the author key of the manifest file and the list of contributors in the license file.

- Sets the min TB version to 128, as this version of Xpunge does not work in TB 115.
  - Error: `Failed to load resource:///modules/MailServices.sys.mjs`
  - Error: `An unexpected error occurred migration.mjs:42:48 - getLegacyPreference`

- Sets the Xpunge version to 5.0.0, which will be the release for TB 128.

- Adds some more logging information.

- Aligns the display of accounts for trash/junk in the prompt dialog for MultiXpunge with the previous version of Xpunge.

- Fixes the parsing of the time value for the absolute timer.