### PR TITLE
Fix absolute timer issue

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "gecko": {
       "id": "{786abda0-fd14-d247-bf69-38b2fc18491b}",
       "strict_min_version": "128.0",
-      "strict_max_version": "130.*"
+      "strict_max_version": "131.*"
     }
   },
 

--- a/modules/migration.mjs
+++ b/modules/migration.mjs
@@ -31,11 +31,18 @@ export async function migratePrefs() {
         }
         
     }
-    // Merge timer_absolute_hours and timer_absolute_minutes.
-    options.preferences_timer_absolute = `${options.preferences_timer_absolute_hours}:${options.preferences_timer_absolute_minutes}`
-    delete options.preferences_timer_absolute_hours;
-    delete options.preferences_timer_absolute_minutes;
-    await browser.storage.local.set(options);
+    // Merge timer_absolute_hours and timer_absolute_minutes (if needed).
+    if (
+        Object.hasOwn(options, "preferences_timer_absolute_hours") &&
+        Object.hasOwn(options, "preferences_timer_absolute_minutes")
+    ) {
+        options.preferences_timer_absolute = `${options.preferences_timer_absolute_hours}:${options.preferences_timer_absolute_minutes}`
+        delete options.preferences_timer_absolute_hours;
+        delete options.preferences_timer_absolute_minutes;
+    }
+    if (Object.keys(options).length) {
+        await browser.storage.local.set(options);
+    }
 }
 
 async function getLegacyPreference(name) {


### PR DESCRIPTION
The issue was caused by the migration code. The main logic was only adding entries to the options object, if they were found in the legacy tree. Since the legacy entry was removed after the migration, the local storage was never touched again by the migration code. Except for `preferences_timer_absolute`, which got overwriten on each run with the values in `options.preferences_timer_absolute_hours` and `options.preferences_timer_absolute_minutes`. After the first migration run, these two would always be undefined and thus clear the stored value in the local storage.

Fixed by checking if the options object actually has entries.