### PR TITLE
Fix migration for default value of absolute time component

### DIFF
--- a/modules/migration.mjs
+++ b/modules/migration.mjs
@@ -31,15 +31,19 @@ export async function migratePrefs() {
         }
         
     }
+
     // Merge timer_absolute_hours and timer_absolute_minutes (if needed).
     if (
-        Object.hasOwn(options, "preferences_timer_absolute_hours") &&
+        Object.hasOwn(options, "preferences_timer_absolute_hours") ||
         Object.hasOwn(options, "preferences_timer_absolute_minutes")
     ) {
-        options.preferences_timer_absolute = `${options.preferences_timer_absolute_hours}:${options.preferences_timer_absolute_minutes}`
+        let hours = options.preferences_timer_absolute_hours ?? "00";
+        let minutes = options.preferences_timer_absolute_minutes ?? "00";
+        options.preferences_timer_absolute = `${hours}:${minutes}`;
         delete options.preferences_timer_absolute_hours;
         delete options.preferences_timer_absolute_minutes;
     }
+
     if (Object.keys(options).length) {
         await browser.storage.local.set(options);
     }


### PR DESCRIPTION
There is still an issue with the migration of the preferences related to the hours/minutes of the absolute timer, specifically when either the hours or the minutes have not been set (i.e. have the default value of "00").

In this scenario, the code does not migrate the non-default value. For example, if the absolute timer in TB 115 & Xpunge 4.0.2 is set to 00:42, after the migration to TB 128 & Xpunge 5.0.0, the absolute timer is reset to the default "00:00".

Fixed by changing the "&&" introduced in PR #3 to "||", and initializing the hours and minutes to either the default value or the value set by the user, before concatenating in the single new property.