### PR TITLE
Increase strict_min_version for RSS issue fix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "{786abda0-fd14-d247-bf69-38b2fc18491b}",
-      "strict_min_version": "128.0",
+      "strict_min_version": "128.2.0",
       "strict_max_version": "131.*"
     }
   },


### PR DESCRIPTION
Increasing the `strict_min_version` for TB in the manifest file, in order to have the fix for the RSS issue available. See https://github.com/theodore-tegos/xpunge-tb/pull/8#issuecomment-2320560827.
