### PR TITLE
Call emptyTrash without urlListener for POP3 accounts

### DIFF
--- a/api/Xpunge/implementation.js
+++ b/api/Xpunge/implementation.js
@@ -103,9 +103,9 @@ var Xpunge = class extends ExtensionCommon.ExtensionAPI {
             folder.accountId,
             folder.path
           ).rootFolder;
-          
+
           const _emptyTrash = async (folder) => {
-            if ((folder.server.type === "none") || (folder.server.type === "rss")) {
+            if (["none", "rss", "pop3"].includes(folder.server.type)) {
               // The implementation of nsMsgLocalMailFolder::EmptyTrash does not call the
               // urlListener
               // https://searchfox.org/comm-central/rev/d9f4b21312781d3abb9c88cade1d077b9e1622f4/mailnews/local/src/nsLocalMailFolder.cpp#615

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
 
   "description": "Empties the Trash and Junk folders, and compacts folders in multiple Thunderbird accounts.",
 
-  "version": "5.0.0",
+  "version": "5.0.1",
 
   "author": "Theodore Tegos, John Bieling",
 


### PR DESCRIPTION
Similar to the issue fixed in #11.

Calling `folder.emptyTrash` with a `urlListener` param doesn't work for POP3 accounts. The `await urlListener.isDone();` statement never completes. 

So we're now calling it with a `null` param, just like when the server type is "none" or "rss".