### PR TITLE
Call emptyTrash without urlListener for exchange/owl accounts

### DIFF
--- a/api/Xpunge/implementation.js
+++ b/api/Xpunge/implementation.js
@@ -105,7 +105,7 @@ var Xpunge = class extends ExtensionCommon.ExtensionAPI {
           ).rootFolder;
 
           const _emptyTrash = async (folder) => {
-            if (["none", "rss", "pop3"].includes(folder.server.type)) {
+            if (["none", "rss", "pop3", "owl"].includes(folder.server.type)) {
               // The implementation of nsMsgLocalMailFolder::EmptyTrash does not call the
               // urlListener
               // https://searchfox.org/comm-central/rev/d9f4b21312781d3abb9c88cade1d077b9e1622f4/mailnews/local/src/nsLocalMailFolder.cpp#615


### PR DESCRIPTION
Similar to the issue fixed in https://github.com/theodore-tegos/xpunge-tb/pull/12.

Calling `folder.emptyTrash` with a `urlListener` param doesn't work for exchange accounts accessed via the Owl add-on. The `await urlListener.isDone();` statement never completes.

So we're now calling it with a null param, just like when the server type is "none", "rss" or "pop3".